### PR TITLE
fix: Upgrade project and workflow to .NET 8

### DIFF
--- a/.github/workflows/build-windows-exe.yml
+++ b/.github/workflows/build-windows-exe.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '7.0.x'   # نیاز به نسخه‌ی مناسب پروژه‌ات: 6.0.x یا 8.0.x در صورت نیاز
+          dotnet-version: '8.0.x'
 
       - name: Restore
         run: dotnet restore SanadBan.csproj

--- a/SanadBan.csproj
+++ b/SanadBan.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <RootNamespace>SanadBan</RootNamespace>


### PR DESCRIPTION
The `dotnet restore` command was failing, likely due to an incompatibility between the Wpf.Ui library and the .NET 7 SDK.

This commit resolves the issue by:
1. Upgrading the project's TargetFramework to `net8.0-windows`.
2. Upgrading the GitHub Actions workflow to use the `.NET 8.0.x` SDK.