### PR TITLE
Fix: Remove reference to missing application icon

### DIFF
--- a/UtilityDocuments.csproj
+++ b/UtilityDocuments.csproj
@@ -5,7 +5,6 @@
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <RootNamespace>UtilityDocuments</RootNamespace>
-    <ApplicationIcon>icon.ico</ApplicationIcon>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The build was failing because the `UtilityDocuments.csproj` file referenced an `icon.ico` file that does not exist in the repository.

This change removes the `<ApplicationIcon>` tag from the project file to resolve the build error. The application will now use the default system icon.