### PR TITLE
Fix: Resolve build and installer creation failures

### DIFF
--- a/Setup/setup.wixproj
+++ b/Setup/setup.wixproj
@@ -3,13 +3,10 @@
     <OutputType>Package</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\UtilityDocuments.csproj" />
-  </ItemGroup>
-  <Target Name="Harvest" BeforeTargets="Build">
-    <Exec Command="dotnet publish &quot;..\UtilityDocuments.csproj&quot; -c $(Configuration) -o &quot;$(IntermediateOutputPath)publish&quot;" />
-    <Exec Command="&quot;$(WixToolPath)heat.exe&quot; dir &quot;$(IntermediateOutputPath)publish&quot; -ag -srd -cg HarvestedComponents -o &quot;$(IntermediateOutputPath)HarvestedComponents.wxs&quot;" />
-  </Target>
-  <ItemGroup>
-    <Compile Include="$(IntermediateOutputPath)HarvestedComponents.wxs" />
+    <ProjectReference Include="..\UtilityDocuments.csproj">
+      <Harvest>True</Harvest>
+      <ProjectOutputGroups>Binaries;Content;Satellites</ProjectOutputGroups>
+      <DirectoryRefId>INSTALLFOLDER</DirectoryRefId>
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/Setup/setup.wxs
+++ b/Setup/setup.wxs
@@ -3,7 +3,7 @@
     <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
 
     <Feature Id="ProductFeature" Title="UtilityDocuments" Level="1">
-      <ComponentGroupRef Id="HarvestedComponents" />
+      <ComponentGroupRef Id="UtilityDocuments.Generated" />
       <ComponentRef Id="ApplicationShortcut" />
     </Feature>
   </Package>


### PR DESCRIPTION
This commit addresses two separate issues that were causing the build to fail:

1.  **Missing Application Icon:** Removed the `<ApplicationIcon>` reference from `UtilityDocuments.csproj` because the specified `icon.ico` file does not exist in the repository. This resolves the initial build failure.

2.  **WiX Installer Error:** Modernized the WiX installer project (`Setup/setup.wixproj`) to resolve a `WIX0103` error (Cannot find `HarvestedComponents.wxs`). The old, manual harvesting process using `heat.exe` was replaced with the modern, automated `HarvestProjectReference` mechanism from the WiX v4+ SDK. The `setup.wxs` file was updated accordingly to reference the auto-generated component group. This makes the installer build process more robust and maintainable.